### PR TITLE
feat(schema): TechArticle + FAQPage for resource guides, with content-gap roadmap

### DIFF
--- a/CONTENT-BRIEF-01-aramco-ppe.md
+++ b/CONTENT-BRIEF-01-aramco-ppe.md
@@ -1,0 +1,219 @@
+# Content Brief #1 — Saudi Aramco PPE & Coverall Vendor Specification Guide
+
+**Status:** Build brief (P1, flagship) · **Prepared:** 2026-06-19 · **For:** writer + industrial/HSE SME review
+
+---
+
+## ⚠️ Accuracy ground rule (read before writing)
+
+Saudi Aramco engineering standards (SAES), General Instructions (GI), minimum arc ratings, approved-vendor mechanics, and the supplier-registration portal are **controlled, version-specific documents**. This brief maps the *standards landscape and buyer questions* — it does **not** assert specific document numbers or threshold values. Every place marked **`[SME-VERIFY]`** must be confirmed by a qualified HSE/procurement SME against current Aramco-controlled sources before publishing. **Do not invent SAES numbers, cal/cm² minimums, or process names.** Where a value can't be confirmed, describe the requirement category and tell the reader to confirm against their contract's flow-down documents. This honesty *is* the E-E-A-T signal — vague-but-correct beats specific-but-wrong, which a procurement reader will instantly distrust.
+
+---
+
+## 1. Page parameters
+
+| Field | Value |
+|---|---|
+| **Proposed URL** | `/resources/aramco-ppe-coverall-vendor-spec-guide/` (+ `/ar/` mirror) |
+| **Primary keyword** | `saudi aramco ppe specification coveralls` |
+| **Secondary keywords** | aramco approved vendor PPE, aramco FR coverall requirements, contractor PPE compliance Saudi Arabia, IKTVA uniform local content, NFPA 2112 coverall supplier Saudi |
+| **Search intent** | Commercial / consideration (a buyer scoping what compliant PPE requires and who can supply it) |
+| **Primary persona** | Procurement lead / HSE manager / supply-chain officer at an **EPC, drilling, maintenance, or industrial-services contractor** that holds or is bidding for Saudi Aramco work — needs site-compliant workforce PPE and wants local-content credit |
+| **Secondary persona** | In-house industrial-safety buyer at a petrochemical operator with Aramco-aligned site rules |
+| **Word count** | 2,200 (range 2,000–2,500) — enough for full standards + process + buyer checklist; not padded |
+| **Page type / schema** | Technical guide → **TechArticle + FAQPage** @graph (see §6) |
+| **Pillar parent** | `/industries/manufacturing/` |
+
+**Search-intent read (no live SERP data — estimate):** this query is asked by someone who already has, or is chasing, Aramco-linked work and needs to (a) understand the compliance bar, (b) de-risk vendor selection, and (c) see how a local manufacturer helps their IKTVA score. The page wins by being the *clearest plain-English map* of a deliberately opaque standards stack — and by converting on "talk to a supplier who has done this."
+
+---
+
+## 2. Title tag, meta description, H1
+
+- **Title tag** (~48 chars): `Saudi Aramco PPE & FR Coverall Spec Guide | UNEOM`
+- **Meta description** (~150 chars): `What Aramco-site PPE requires: FR coverall standards, arc ratings, hi-vis classes, the vendor-approval route, and how IKTVA local content wins bids.`
+- **H1:** `Saudi Aramco PPE & Coverall Vendor Specification Guide`
+- **Opening lead (for speakable + AI overview):** one 2–3 sentence answer that defines "Aramco-compliant PPE," names the core standard families (FR flash-fire, arc, hi-vis), and states that local manufacturing affects IKTVA scoring. This lead is the snippet/AI-overview target — make it self-contained and factual.
+
+---
+
+## 3. Section-by-section outline (H2 / H3 + what each must cover)
+
+**H2 · Who must meet Aramco PPE requirements (and what "compliant" means)**
+- Define the audience: contractors and sub-contractors working on Aramco facilities/sites; the flow-down of PPE obligations from the prime contract.
+- Clarify that "Aramco-compliant" = meeting the PPE clauses referenced in the contract and the site's safety requirements, *not* a single universal certificate. `[SME-VERIFY]` the correct way to phrase the obligation flow-down.
+- Entities: Saudi Aramco, contractor/sub-contractor, HSE flow-down, Eastern Province operating areas (Dhahran, Abqaiq, Ras Tanura, Khurais) `[SME-VERIFY]` site list relevance.
+
+**H2 · How Aramco PPE governance is structured: the standards stack**
+- Explain (at a category level) the document families a contractor encounters: **SAES** (Saudi Aramco Engineering Standards), **SAEP** (Engineering Procedures), **GI** (General Instructions), and contract-specific safety requirements. `[SME-VERIFY]` which families actually carry PPE clauses; **do not cite specific numbers**.
+- Frame it as "your contract will reference controlled documents — here's how to read which ones govern garments."
+- H3 · Where uniform/coverall requirements typically live in that stack `[SME-VERIFY]`.
+
+**H2 · FR coverall requirements for Aramco sites**
+- The core of the page. Cover the *recognised FR standard families* a compliant coverall is tested to: **NFPA 2112** (flash-fire garment certification), **arc rating** per **NFPA 70E / ASTM F1506** (where arc-flash exposure applies), **EN ISO 11612** (heat/flame), and **EN ISO 11611** for welding tasks.
+- **Inherent vs treated FR:** aramid/modacrylic blends (e.g., Nomex-type) vs treated cotton (Proban/Pyrovatex-type) — durability, wash-life of FR, comfort, cost. Link to the sibling FR pages rather than re-deriving.
+- **Arc rating concepts:** ATPV (cal/cm²), arc rating, PPE category/HRC — explain the *concept*; **state actual minimums only if `[SME-VERIFY]` confirms them**, else say "your contract/SEPM specifies the minimum arc rating for the task."
+- **Colour & identification:** contractor vs operator colour conventions, name/company ID, anti-static where required (**EN 1149**). `[SME-VERIFY]` any prescribed colours.
+- Entities: NFPA 2112, NFPA 70E, ASTM F1506, EN ISO 11612, EN ISO 11611, EN 1149, ATPV, arc rating, HRC/PPE category, inherent FR, treated FR, flash fire, modacrylic, aramid.
+
+**H2 · The rest of the ensemble: hi-vis, head-to-toe & heat**
+- Hi-vis garment classes: **ANSI/ISEA 107** and **ISO 20471** class selection by role (ramp/road/site). Link to the existing manufacturing/PPE content rather than duplicating the hi-vis page.
+- How FR + hi-vis + anti-static requirements combine in one ensemble; coverall vs two-piece; accessories scope (note where the page stops — this page is garments/coveralls, not respirators/footwear).
+- Heat interplay: Eastern Province summer load vs FR coverage — segue to the heat-stress section.
+
+**H2 · Becoming an Aramco-recognised PPE supplier: the approval pathway**
+- Explain, at a process level, how a garment/vendor gets used on Aramco work: supplier registration, product qualification, and the **evidence package** a buyer must collect — third-party test certificates (e.g., NFPA 2112 certification, EN ISO test reports), traceability, and conformity documentation. `[SME-VERIFY]` the current registration portal/route and any "approved vendor"/qualification mechanics; **do not name a specific portal or 9COM-type process unless confirmed.**
+- H3 · The test-certificate checklist a contractor should demand from any coverall supplier (this is genuinely useful and safe to write): garment certification to the named FR standard, batch/lot traceability, wash-durability evidence, OEKO-TEX Standard 100 for skin safety, SASO conformity where applicable.
+- Entities: third-party testing, certification body, OEKO-TEX Standard 100, SASO, conformity documentation, traceability.
+
+**H2 · IKTVA & local content: why in-Kingdom manufacturing wins the bid**
+- The strategic differentiator. Explain **IKTVA (In-Kingdom Total Value Add)** — Aramco's supplier-localization programme — and how local content / Saudization affects contractor scoring and supplier preference. `[SME-VERIFY]` exact IKTVA scoring mechanics; describe the principle confidently (IKTVA is real and central) but don't invent percentages.
+- Position UNEOM honestly: an in-Kingdom manufacturer (ISO 9001 + OEKO-TEX) whose local production contributes to a contractor's local-content story. **No fabricated stats.**
+- **Strong internal link** into the magnet: `/resources/made-in-saudi-uniform-local-content-guide/`.
+- Entities: IKTVA, In-Kingdom Total Value Add, local content, Saudization/Nitaqat, Vision 2030, Made in Saudi.
+
+**H2 · Heat-stress management within FR constraints (Eastern Province reality)**
+- Fabric weight/GSM trade-offs inside FR limits, moisture management, breathability; reference work-rest cycling and WBGT as *general industry practice*, not medical/legal advice (add a one-line "follow your site's HSE heat-stress procedures" disclaimer). `[SME-VERIFY]` any site-specific heat rules.
+- Link to `/resources/cooling-moisture-wicking-fabric-guide/` and `/blog/industrial-heat-stress-management/`.
+
+**H2 · Sizing, fit & rolling out PPE across a large contractor workforce**
+- Fit at scale (wear trials, size-set sampling), industrial FR laundering that preserves FR performance, replacement cycles and TCO. Link to `/services/program-management/` and the FR buyer's guide.
+
+**H2 · Procurement checklist: what to require from your coverall supplier**
+- A scannable 8–10 item checklist (test certs to the named standard, arc rating evidence where relevant, traceability, OEKO-TEX, local-content documentation, MOQ, lead time, fit/wear-trial support, laundering guidance, reorder SLA). This is the conversion-adjacent "save/share" asset.
+
+**H2 · FAQ** (powers the FAQPage schema — see §5)
+
+**Closing CTA** — "Request an Aramco-site PPE consultation / compliant FR coverall quote" → `/quote/` and `/services/program-management/`.
+
+---
+
+## 4. Entities to cover (entity-SEO completeness list)
+
+Confirm presence of these named entities for topical/entity completeness (each `[SME-VERIFY]` for specific values):
+Saudi Aramco · IKTVA (In-Kingdom Total Value Add) · SAES / SAEP / GI (standard families) · NFPA 2112 · NFPA 70E · ASTM F1506 · EN ISO 11612 · EN ISO 11611 · EN 1149 (anti-static) · ANSI/ISEA 107 · ISO 20471 · ATPV / arc rating / cal·cm⁻² · HRC / PPE category · inherent vs treated FR · aramid / modacrylic / Proban / Pyrovatex · OEKO-TEX Standard 100 · SASO · HCIS (High Commission for Industrial Security) · Eastern Province (Dhahran/Abqaiq/Ras Tanura) · heat stress / WBGT · industrial FR laundering · Saudization / Vision 2030.
+
+---
+
+## 5. FAQ block (write concise, factual answers; flag any value to verify)
+
+1. **What PPE standards must coveralls meet for Saudi Aramco sites?** — Name the FR standard families (NFPA 2112, arc per NFPA 70E/ASTM F1506, EN ISO 11612) and say the exact requirement is set by the contract's flow-down. `[SME-VERIFY]`
+2. **Does Saudi Aramco require inherent or treated FR coveralls?** — Explain both are used; the determinant is the contract spec and durability/cost trade-off, not a blanket rule. `[SME-VERIFY]`
+3. **How does a uniform/PPE supplier become approved to supply Aramco contractors?** — Describe registration + product qualification + evidence package at a category level. `[SME-VERIFY]` process specifics.
+4. **What is IKTVA and why does local content matter for PPE procurement?** — Define IKTVA and explain local-content benefit to contractor scoring. (Principle is safe; percentages `[SME-VERIFY]`.)
+5. **What test certificates should I ask a coverall supplier for?** — The checklist answer (safe to write fully).
+6. **Are UNEOM coveralls Saudi Aramco approved?** — Answer honestly about in-Kingdom manufacturing, certifications held (ISO 9001, OEKO-TEX), and the ability to supply to the contract's stated FR standard — **without claiming an approval status that isn't held.** `[SME-VERIFY]` exact claim.
+
+---
+
+## 6. Exact on-page JSON-LD (paste-ready, matches the site's @id graph conventions)
+
+Drop this as one `<script type="application/ld+json">` block. It is a single connected `@graph` that references the site-wide `Organization` and `WebSite` nodes (emitted in the layout) by `@id`, exactly like the other templates. Uses **TechArticle** (more specific than Article for a technical guide) + **FAQPage** + breadcrumb + primary image.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#webpage",
+      "url": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/",
+      "name": "Saudi Aramco PPE & Coverall Vendor Specification Guide",
+      "description": "What Aramco-site PPE requires: FR coverall standards, arc ratings, hi-vis classes, the vendor-approval route, and how IKTVA local content wins bids.",
+      "isPartOf": { "@id": "https://uneom.com/#website" },
+      "about": { "@id": "https://uneom.com/#organization" },
+      "publisher": { "@id": "https://uneom.com/#organization" },
+      "inLanguage": "en",
+      "primaryImageOfPage": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#primaryimage" },
+      "image": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#primaryimage" },
+      "breadcrumb": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#breadcrumb" },
+      "mainEntity": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#article" },
+      "speakable": { "@type": "SpeakableSpecification", "cssSelector": ["h1", ".lead"] }
+    },
+    {
+      "@type": "ImageObject",
+      "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#primaryimage",
+      "url": "https://uneom.com/images/resources/aramco-ppe-coverall-vendor-spec-guide.avif",
+      "contentUrl": "https://uneom.com/images/resources/aramco-ppe-coverall-vendor-spec-guide.avif",
+      "width": 1920,
+      "height": 1080,
+      "caption": "Aramco-compliant flame-resistant coveralls for Saudi industrial sites"
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#article",
+      "headline": "Saudi Aramco PPE & Coverall Vendor Specification Guide",
+      "description": "A buyer's guide to FR coverall standards, arc ratings, hi-vis classes, the Aramco vendor-approval pathway, and IKTVA local content for Saudi industrial contractors.",
+      "image": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#primaryimage" },
+      "author": { "@id": "https://uneom.com/#organization" },
+      "publisher": { "@id": "https://uneom.com/#organization" },
+      "isPartOf": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#webpage" },
+      "mainEntityOfPage": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#webpage" },
+      "inLanguage": "en",
+      "datePublished": "2026-07-01",
+      "dateModified": "2026-07-01",
+      "about": [
+        { "@type": "Thing", "name": "Personal protective equipment" },
+        { "@type": "Thing", "name": "Flame-resistant clothing" },
+        { "@type": "Organization", "name": "Saudi Aramco" }
+      ],
+      "proficiencyLevel": "Expert",
+      "keywords": "saudi aramco ppe, FR coverall, NFPA 2112, arc rating, IKTVA local content, contractor PPE compliance Saudi Arabia"
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#faq",
+      "isPartOf": { "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#webpage" },
+      "mainEntity": [
+        { "@type": "Question", "name": "What PPE standards must coveralls meet for Saudi Aramco sites?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — name the FR standard families (NFPA 2112 flash-fire certification, arc rating per NFPA 70E / ASTM F1506 where arc-flash applies, EN ISO 11612) and state that the binding requirement is set by the contract's flow-down documents. [SME-VERIFY before publish]" } },
+        { "@type": "Question", "name": "Does Saudi Aramco require inherent or treated FR coveralls?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — both inherent (aramid/modacrylic) and treated (Proban/Pyrovatex) FR are used; the determinant is the contract specification and the durability/cost trade-off, not a blanket rule. [SME-VERIFY]" } },
+        { "@type": "Question", "name": "How does a PPE supplier become approved to supply Saudi Aramco contractors?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — describe supplier registration, product qualification, and the evidence package (third-party test certificates, traceability, conformity docs) at a category level. [SME-VERIFY process specifics]" } },
+        { "@type": "Question", "name": "What is IKTVA and why does local content matter for PPE procurement?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — define IKTVA (In-Kingdom Total Value Add), Saudi Aramco's supplier-localization programme, and explain how local content strengthens a contractor's evaluation and supplier preference. [SME-VERIFY scoring specifics]" } },
+        { "@type": "Question", "name": "What test certificates should I require from a coverall supplier?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — garment certification to the named FR standard, arc-rating evidence where relevant, batch/lot traceability, wash-durability data, OEKO-TEX Standard 100, and SASO conformity where applicable." } }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/#breadcrumb",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://uneom.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Resources", "item": "https://uneom.com/resources/" },
+        { "@type": "ListItem", "position": 3, "name": "Saudi Aramco PPE & Coverall Vendor Specification Guide", "item": "https://uneom.com/resources/aramco-ppe-coverall-vendor-spec-guide/" }
+      ]
+    }
+  ]
+}
+```
+
+**Implementation note:** the site already has `guideSchema()` in `src/lib/seo/schemas.ts`, which emits `WebPage + Article + ImageObject`. For this page either (a) extend `guideSchema` to accept `type: 'TechArticle'` and an optional `faqs` array, or (b) compose `webPageSchema()` + a `faqSchema()` block on the page (the FAQ section already pairs with `faqSchema`). The `@id`s above match the conventions in that file, so it slots into the existing graph with no collisions.
+
+---
+
+## 7. Internal linking (final, all targets verified real)
+
+- **Pillar parent (and breadcrumb):** `/industries/manufacturing/`
+- **Inbound — add links FROM these existing pages, with anchors:**
+  - `/industries/manufacturing/` → "Saudi Aramco PPE & coverall vendor specifications"
+  - `/resources/electrical-safety-ppe-guide/` → "Aramco-site FR coverall & arc-rating requirements"
+  - `/blog/industrial-safety-workwear-saudi/` → "meeting Aramco PPE standards"
+  - `/case-studies/factory-safety-improvement/` → "HRC2 inherent-FR programme for an Aramco-linked site"
+- **Outbound — link TO (existing + sibling new pages), with anchors:**
+  - `/resources/fr-coverall-buyer-guide-saudi/` (sibling) → "inherent vs treated FR coverall buyer's guide"
+  - `/resources/made-in-saudi-uniform-local-content-guide/` (sibling, magnet) → "in-Kingdom manufacturing & IKTVA local content"
+  - `/resources/cooling-moisture-wicking-fabric-guide/` (sibling) → "managing heat stress within FR constraints"
+  - `/services/program-management/` → "managed PPE programme rollout"
+  - `/shop/manufacturing/` → "HRC2 FR coveralls & hi-vis"
+  - `/quote/` → conversion CTA
+
+---
+
+## 8. Pre-publish checklist
+
+- [ ] Every `[SME-VERIFY]` resolved or rephrased to a safe category statement — **no invented SAES numbers, arc minimums, or portal names**
+- [ ] No fabricated approval claims about UNEOM; certifications stated are real (ISO 9001, OEKO-TEX)
+- [ ] FAQ answers written out (replace the `ANSWER —` placeholders) and matching the visible on-page FAQ text verbatim (schema must mirror page)
+- [ ] Primary image rendered at the `#primaryimage` URL (or update the path in the JSON-LD)
+- [ ] `datePublished` / `dateModified` set to real publish date
+- [ ] Inbound links added from the 4 existing pages (don't ship an orphan)
+- [ ] AR mirror at `/ar/resources/aramco-ppe-coverall-vendor-spec-guide/` with `inLanguage: ar-SA` and hreflang reciprocity
+- [ ] Validate the JSON-LD in Google Rich Results Test (FAQ + breadcrumb eligible)

--- a/CONTENT-BRIEF-24-made-in-saudi-local-content.md
+++ b/CONTENT-BRIEF-24-made-in-saudi-local-content.md
@@ -1,0 +1,252 @@
+# Content Brief #24 — Made-in-Saudi Uniforms: Local Content, Saudization & the In-Kingdom Advantage
+
+**Status:** Build brief (P1, pillar-hub / authority magnet) · **Prepared:** 2026-06-19 · **For:** writer + procurement SME review
+
+> **Why this page is special:** it is one of the two **authority magnets** in the 30-page plan. Almost every tender-facing page (Aramco PPE, GACA aviation, MoE schools, government, giga-projects, procurement) links *into* it. Its job is to convert UNEOM's single biggest structural advantage — **in-Kingdom manufacturing** — into a measurable buyer benefit (local-content tender score). Build it early so the other pages have a destination to point at.
+
+---
+
+## ⚠️ Accuracy ground rule (read before writing)
+
+Saudi local-content policy is governed by **named authorities and version-specific mechanics** (preference percentages, the mandatory list, certificate rules, programme names that have been restructured). This brief maps the *landscape and the buyer logic* — it does **not** assert current percentages, thresholds, or that a specific programme still carries a specific name. Every value marked **`[SME-VERIFY]`** must be confirmed against current official sources (the Local Content & Government Procurement Authority, iktva/Aramco, the "Saudi Made" programme, GACA) before publishing. **Do not invent preference percentages or certificate thresholds.** Describe the mechanism confidently (the *principle* is stable and real); confirm the *numbers* separately. For UNEOM's own credentials, state only what is true (in-Kingdom manufacturing, ISO 9001, OEKO-TEX) — **no fabricated local-content score, employee counts, or certificate IDs.**
+
+---
+
+## 1. Page parameters
+
+| Field | Value |
+|---|---|
+| **Proposed URL** | `/resources/made-in-saudi-uniform-local-content-guide/` (+ `/ar/` mirror) |
+| **Primary keyword** | `made in saudi uniforms` |
+| **Secondary keywords** | local content uniform Saudi Arabia, iktva uniform supplier, Saudi Made uniform manufacturer, local content certificate uniforms, Saudization uniform manufacturing, صنع في السعودية زي موحد |
+| **Search intent** | Commercial / consideration (a buyer or bid-writer evaluating how local sourcing affects their tender and supplier choice) |
+| **Primary persona** | Bid / procurement manager assembling a tender response where **local-content scoring** matters — government, Aramco/iktva contractors, aviation (GACA), education (MoE), giga-projects |
+| **Secondary persona** | Procurement director benchmarking suppliers; CSR/Vision-2030 lead who needs a localisation story |
+| **Word count** | 2,800 (range 2,600–3,000) — pillar depth; it must read as the definitive reference and host the cluster's inbound links |
+| **Page type / schema** | Pillar guide → **Article + FAQPage** @graph (emitted via the upgraded `guideSchema()`; see §6) |
+| **Pillar parent (breadcrumb)** | Home → Resources → this page (top-level hub; not nested under one industry) |
+
+**Search-intent read (no live data — estimate):** the searcher is *not* casually curious — they are deciding whether sourcing locally changes their bid score or supplier shortlist. The page wins by being the clearest plain-English explanation of *how local content is actually scored in Saudi tenders* and *what a uniform supplier must provide* to help that score — then positioning UNEOM honestly as an in-Kingdom manufacturer.
+
+---
+
+## 2. Title tag, meta description, H1
+
+- **Title tag** (~52 chars): `Made-in-Saudi Uniforms: Local Content Guide | UNEOM`
+- **Meta description** (~150 chars): `How local content & Saudization affect Saudi uniform tenders — iktva, the local-content certificate, Saudi Made, and what to require from your supplier.`
+- **H1:** `Made-in-Saudi Uniforms: Local Content, Saudization & the In-Kingdom Advantage`
+- **Opening lead (speakable / AI-overview target):** 2–3 sentences that state plainly: local content is now a scored, often decisive factor in Saudi government and semi-government tenders; "made in Saudi" uniforms can raise that score; and this guide explains the mechanics and what to demand from a supplier. Self-contained, factual, no numbers unless `[SME-VERIFY]`.
+
+---
+
+## 3. Section-by-section outline (H2 / H3 + what each must cover)
+
+**H2 · Why local content now decides Saudi tenders**
+- The Vision 2030 shift from lowest-price to local-value procurement; localisation as national policy.
+- Set the stakes for the reader: in many public and semi-public tenders, local content is a *weighted, scored* criterion — sometimes the tie-breaker. `[SME-VERIFY]` how to phrase weighting without a fabricated %.
+- Entities: Vision 2030, NIDLP (National Industrial Development and Logistics Program), localisation.
+
+**H2 · The local-content landscape: who governs what**
+- A clear map of the programmes a uniform buyer encounters, each defined in 2–3 sentences (principle-level, `[SME-VERIFY]` current names/scope):
+  - **LCGPA** — Local Content & Government Procurement Authority: governs local content in *government* procurement (mandatory list, price preference, the local-content certificate). `[SME-VERIFY]` current authority name/structure.
+  - **iktva** (In-Kingdom Total Value Add) — Saudi Aramco's supplier-localisation programme (the score that matters on Aramco-linked work).
+  - **"Saudi Made" / صنع في السعودية** — the national product-origin programme/mark (register products as Saudi-made).
+  - **Nitaqat** — Saudization (workforce localisation) under MHRSD.
+  - **GACA local content** — aviation-sector localisation (cross-link the aviation page).
+- H3 · How these overlap (a buyer may face *several at once* on one bid).
+- Entities: LCGPA, iktva, Saudi Made, Nitaqat, MHRSD, GACA, Monsha'at, MODON.
+
+**H2 · How local content is scored in a tender (the buyer's mechanics)**
+- Explain the *mechanisms* at principle level: a local-content **weighting/score** in evaluation, a **price preference** for local products/SMEs, and a **mandatory list** of items that must be locally sourced in government procurement. **State percentages only if `[SME-VERIFY]` confirms current values**; otherwise say "a defined preference margin applies — confirm the current figure for your tender."
+- H3 · Where uniforms/PPE fall in this (apparel/textile local sourcing).
+- Entities: price preference, mandatory list, local-content weighting, Etimad (the e-procurement platform where this is administered).
+
+**H2 · What "made in Saudi" actually means for a uniform (and what it doesn't)**
+- The honesty section that builds trust. Distinguish: fully in-Kingdom manufacture vs. cut-make-trim locally with imported fabric vs. imported-and-rebranded. Explain that local-content *value* is measured, not a binary badge.
+- Position UNEOM truthfully: in-Kingdom production, ISO 9001 + OEKO-TEX — **without claiming a local-content percentage or "100% Saudi-made" unless verified.** `[SME-VERIFY]` any specific claim.
+- Entities: cut-make-trim, fabric origin, value-add, in-Kingdom manufacturing.
+
+**H2 · The Local-Content Certificate: how your uniform supplier raises *your* score**
+- Explain the **local-content certificate** concept (a supplier's measured local-content baseline used in tenders) and the documentation a buyer should collect from a uniform supplier to claim local value. `[SME-VERIFY]` certificate issuer/process and current name.
+- H3 · The document checklist to request from a uniform supplier (safe to write fully): proof of in-Kingdom manufacturing, local-content certificate/baseline where available, Saudi Made registration where applicable, Saudization data, and traceability.
+- Entities: local-content certificate, supplier baseline, traceability.
+
+**H2 · Saudization in uniform manufacturing**
+- The workforce-localisation angle: Nitaqat bands, Saudi jobs in cut-make-trim and programme management, and why a buyer's localisation/CSR story benefits from a Saudi-staffed supplier. `[SME-VERIFY]` Nitaqat band specifics; **no fabricated UNEOM headcount.**
+- Cross-link `/about/`.
+
+**H2 · Local content by sector (and where to go deeper)**
+- Short sub-sections, each 2–4 sentences, each linking to the relevant sibling page:
+  - Government & ministries → `/industries/government-uniforms/`
+  - Oil & gas / Aramco (iktva) → `/resources/aramco-ppe-coverall-vendor-spec-guide/`
+  - Aviation (GACA local content) → `/resources/gaca-local-content-aviation-uniform-procurement/`
+  - Education (MoE / Etimad) → `/resources/school-uniform-moe-tender-guide/`
+  - Giga-projects → `/industries/giga-project-uniforms/`
+- This is the **hub mechanism** — the section that makes the magnet a magnet.
+
+**H2 · Local content and sustainability (the shorter-supply-chain bonus)**
+- In-Kingdom manufacturing shortens the supply chain (lead time, freight emissions, responsiveness). Link `/resources/sustainability-guide/`. Keep claims qualitative unless data exists.
+
+**H2 · Choosing a local-content-credible uniform partner**
+- A scannable checklist (in-Kingdom production evidence, local-content documentation, Saudization, capacity to scale, programme management, traceability) — the conversion-adjacent save/share asset.
+
+**H2 · FAQ** (powers FAQPage schema — see §5)
+
+**Closing CTA** — "Build a local-content-credible uniform programme — request a consultation" → `/quote/` and `/services/program-management/`.
+
+---
+
+## 4. Entities to cover (entity-SEO completeness list)
+
+Vision 2030 · NIDLP · **LCGPA** (Local Content & Government Procurement Authority) · **iktva** (In-Kingdom Total Value Add) · **Saudi Made / صنع في السعودية** · **Nitaqat** / Saudization · MHRSD · GACA local content · Etimad · mandatory list · price preference · local-content certificate · cut-make-trim · in-Kingdom value-add · MODON · Monsha'at · ISO 9001 · OEKO-TEX Standard 100. *(Each `[SME-VERIFY]` for current names/values.)*
+
+---
+
+## 5. FAQ block (write factual answers; flag any value to verify)
+
+1. **Does buying made-in-Saudi uniforms improve my tender score?** — Explain local content is a scored/weighted factor in many government and semi-government tenders and local sourcing can raise it; the exact weighting depends on the tender. `[SME-VERIFY]`
+2. **What is the difference between iktva and the government local-content certificate?** — iktva = Aramco's supplier-localisation programme; the local-content certificate = the government-procurement local-content baseline. A supplier may need both for different buyers. `[SME-VERIFY]`
+3. **What documents should I request from a uniform supplier to claim local content?** — The checklist answer (safe to write fully).
+4. **What does "Saudi Made" mean for uniforms?** — Define the national product-origin programme/mark and how a uniform manufacturer registers/qualifies. `[SME-VERIFY]` current programme mechanics.
+5. **Are UNEOM uniforms made in Saudi Arabia?** — Answer honestly about in-Kingdom manufacturing and held certifications (ISO 9001, OEKO-TEX) **without stating a local-content percentage that isn't verified.** `[SME-VERIFY]` exact claim.
+6. **How does Saudization affect uniform procurement?** — Explain Nitaqat/workforce localisation and why a Saudi-staffed supplier supports a buyer's localisation story. `[SME-VERIFY]`
+
+---
+
+## 6. Build-ready: data entry + exact JSON-LD (uses the upgraded `guideSchema`)
+
+Because `guideSchema()` now supports `faqs` and `schemaType`, this page is created simply by adding a `Resource` entry — the FAQPage + Article graph is emitted automatically and the FAQ renders visibly. **Data shape:**
+
+```ts
+// src/lib/data/resources/made-in-saudi-uniform-local-content-guide.ts
+export const madeInSaudiLocalContentGuide: Resource = {
+  slug: 'made-in-saudi-uniform-local-content-guide',
+  title: 'Made-in-Saudi Uniforms: Local Content, Saudization & the In-Kingdom Advantage',
+  titleAr: '…',
+  summary: 'How local content and Saudization affect Saudi uniform tenders — and what to require from your supplier.',
+  summaryAr: '…',
+  hero: 'resources/made-in-saudi-local-content-hero',
+  silo: 'corporate',                 // or a dedicated hub silo
+  readingMinutes: 14,
+  schemaType: 'Article',             // strategic pillar guide (TechArticle also acceptable)
+  datePublished: '2026-07-01',
+  lead: '…', leadAr: '…',
+  sections: [ /* the H2 outline above */ ],
+  sectionsAr: [ /* … */ ],
+  faqs: [ /* the §5 FAQ, answers SME-verified */ ],
+  faqsAr: [ /* … */ ],
+  references: [ /* official LCGPA / iktva / Saudi Made / GACA sources */ ],
+};
+```
+
+The resulting JSON-LD `@graph` (auto-generated, shown here so you can verify in Rich Results Test — `@id`s match the site graph and reference the layout's `Organization`/`WebSite`):
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#webpage",
+      "url": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/",
+      "name": "Made-in-Saudi Uniforms: Local Content, Saudization & the In-Kingdom Advantage",
+      "description": "How local content and Saudization affect Saudi uniform tenders — and what to require from your supplier.",
+      "isPartOf": { "@id": "https://uneom.com/#website" },
+      "about": { "@id": "https://uneom.com/#organization" },
+      "publisher": { "@id": "https://uneom.com/#organization" },
+      "inLanguage": "en",
+      "primaryImageOfPage": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#primaryimage" },
+      "breadcrumb": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#breadcrumb" },
+      "mainEntity": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#article" },
+      "speakable": { "@type": "SpeakableSpecification", "cssSelector": ["h1"] }
+    },
+    {
+      "@type": "ImageObject",
+      "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#primaryimage",
+      "url": "https://uneom.com/images/resources/made-in-saudi-local-content-hero.avif",
+      "contentUrl": "https://uneom.com/images/resources/made-in-saudi-local-content-hero.avif",
+      "width": 1920, "height": 1080,
+      "caption": "Made-in-Saudi professional uniforms — in-Kingdom manufacturing"
+    },
+    {
+      "@type": "Article",
+      "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#article",
+      "headline": "Made-in-Saudi Uniforms: Local Content, Saudization & the In-Kingdom Advantage",
+      "description": "How local content and Saudization affect Saudi uniform tenders — iktva, the local-content certificate, Saudi Made, and supplier requirements.",
+      "image": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#primaryimage" },
+      "author": { "@id": "https://uneom.com/#organization" },
+      "publisher": { "@id": "https://uneom.com/#organization" },
+      "isPartOf": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#webpage" },
+      "mainEntityOfPage": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#webpage" },
+      "inLanguage": "en",
+      "datePublished": "2026-07-01",
+      "dateModified": "2026-07-01",
+      "about": [
+        { "@type": "Thing", "name": "Local content" },
+        { "@type": "Thing", "name": "Saudization" },
+        { "@type": "Thing", "name": "iktva" }
+      ],
+      "keywords": "made in saudi uniforms, local content, iktva, Saudi Made, Saudization, local content certificate"
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#faq",
+      "isPartOf": { "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#webpage" },
+      "inLanguage": "en",
+      "mainEntity": [
+        { "@type": "Question", "name": "Does buying made-in-Saudi uniforms improve my tender score?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — local content is a scored/weighted factor in many Saudi government and semi-government tenders; local sourcing can raise it, with the exact weighting set by the tender. [SME-VERIFY]" } },
+        { "@type": "Question", "name": "What is the difference between iktva and the government local-content certificate?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — iktva is Saudi Aramco's supplier-localisation programme; the local-content certificate is the government-procurement local-content baseline. Different buyers may require different ones. [SME-VERIFY]" } },
+        { "@type": "Question", "name": "What documents should I request from a uniform supplier to claim local content?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — proof of in-Kingdom manufacturing, a local-content certificate/baseline where available, Saudi Made registration where applicable, Saudization data, and production traceability." } },
+        { "@type": "Question", "name": "Are UNEOM uniforms made in Saudi Arabia?", "acceptedAnswer": { "@type": "Answer", "text": "ANSWER — state honestly: in-Kingdom manufacturing, ISO 9001 and OEKO-TEX certified, supplying to the tender's stated local-content requirement, without claiming an unverified local-content percentage. [SME-VERIFY]" } }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/#breadcrumb",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://uneom.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Resources", "item": "https://uneom.com/resources/" },
+        { "@type": "ListItem", "position": 3, "name": "Made-in-Saudi Uniforms: Local Content & In-Kingdom Advantage", "item": "https://uneom.com/resources/made-in-saudi-uniform-local-content-guide/" }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 7. Internal linking — this is the magnet (heavy inbound)
+
+**Pillar parent / breadcrumb:** Home → Resources → this page (top-level hub).
+
+**Inbound — every tender-facing page links IN, with anchors:**
+- `/resources/aramco-ppe-coverall-vendor-spec-guide/` → "in-Kingdom manufacturing & iktva local content"
+- `/resources/gaca-local-content-aviation-uniform-procurement/` → "Made-in-Saudi local content advantage"
+- `/resources/school-uniform-moe-tender-guide/` → "local content & iktva scoring in school tenders"
+- `/industries/government-uniforms/` → "local-content requirements in government procurement"
+- `/industries/giga-project-uniforms/` → "local content on Vision 2030 megaprojects"
+- `/resources/procurement-guide/` → "how local content affects supplier selection"
+- `/blog/uniform-procurement-tender-guide-saudi/` → "winning on local content"
+- `/blog/national-day-corporate-uniforms/` → "Saudi-made uniform manufacturing"
+- `/about/` → "our in-Kingdom manufacturing"
+
+**Outbound — links OUT to (existing + the sibling sector pages, with anchors):**
+- `/industries/government-uniforms/`, `/resources/aramco-ppe-coverall-vendor-spec-guide/`, `/resources/gaca-local-content-aviation-uniform-procurement/`, `/resources/school-uniform-moe-tender-guide/`, `/industries/giga-project-uniforms/` (the sector deep-links)
+- `/services/program-management/` → "managed local uniform programme"
+- `/resources/sustainability-guide/` → "shorter, lower-emission supply chain"
+- `/industries/manufacturing/` → "industrial uniform manufacturing"
+- `/about/`, `/quote/` (CTA)
+
+> **Linking rule:** because this is a magnet, prioritise getting the **inbound** links live. The page's authority comes from being pointed at by every high-value tender page — don't ship it as an island.
+
+---
+
+## 8. Pre-publish checklist
+
+- [ ] Every `[SME-VERIFY]` resolved or rephrased to a safe principle-level statement — **no invented preference %, certificate thresholds, or restructured programme names stated as current**
+- [ ] No fabricated UNEOM local-content score, headcount, or certificate ID; only real credentials (in-Kingdom manufacturing, ISO 9001, OEKO-TEX)
+- [ ] FAQ answers written out (replace `ANSWER —`) and matching the visible on-page FAQ verbatim
+- [ ] `references` point to official sources (Local Content authority, iktva/Aramco, Saudi Made, GACA)
+- [ ] Inbound links added from all 9 listed pages **before/at launch** (a magnet with no inbound links is wasted)
+- [ ] AR mirror at `/ar/resources/made-in-saudi-uniform-local-content-guide/`, `inLanguage: ar-SA`, hreflang reciprocity
+- [ ] Validate JSON-LD in Rich Results Test (FAQ + breadcrumb eligible)

--- a/CONTENT-GAP-ANALYSIS-2026.md
+++ b/CONTENT-GAP-ANALYSIS-2026.md
@@ -1,0 +1,289 @@
+# UNEOM Content Gap Analysis — Top 30 Pages for Unbeatable Topical Authority
+
+**Domain:** https://uneom.com · **Market:** Saudi Arabia B2B professional uniforms · **Prepared:** 2026-06-19
+
+---
+
+## How to read this (methodology + honest data caveat)
+
+This roadmap was built in three passes: (1) a full inventory of **every page that already exists** on the site (8 industry pillars, 8 shop categories, 7 services, 13 resources, 19 blog posts, 8 case studies, 24 city pages) so nothing recommended duplicates existing content; (2) a 10-cluster gap sweep that generated 97 candidate pages; (3) selection of the 30 highest-leverage pages, balanced across clusters and the buyer journey, with internal linking mapped to **real existing URLs**.
+
+**Data caveat — read this.** Both connected keyword tools (Ahrefs and Semrush MCP) returned *"insufficient plan"* for every data endpoint, so **no live search-volume or difficulty numbers were available**. Every `Demand` and `Commercial value` rating below is a **labelled expert estimate** based on Saudi B2B market structure, buyer behaviour, and SERP logic — *not* measured volume. When you enable a data plan or grant Search Console access, the same 30 keywords can be re-scored with real numbers in an afternoon. Treat the *priorities and the architecture* as the durable output; treat the demand tiers as directional.
+
+**Rating key:** Demand/Commercial = High / Med / Low (estimates). Priority P1 = build first (highest leverage), P2 = second wave, P3 = fill-in.
+
+---
+
+## The strategy in one picture: hubs, spokes, and two magnets
+
+Topical authority is not 30 isolated articles — it is a **linked graph**. These 30 are engineered as four structural roles:
+
+- **6 new pillar-hubs** that each open a sub-cluster the site currently has no home for: *Government uniforms*, *Giga-project workforce uniforms*, *University & higher-ed uniforms*, *Facility-management uniforms*, *Made-in-Saudi local content*, and a top-level *Saudi Uniform Buyer's Guide*.
+- **Cluster spokes** (specialty/role/segment pages) that hang off both the new hubs and your **existing** industry pillars.
+- **Decision pages** (comparisons, rent-vs-buy, branding methods) that capture bottom-funnel intent and convert.
+- **Two "magnet" pages** — `Made-in-Saudi local content` and the `Buyer's Guide` — that nearly every other new page links *into*, concentrating authority where it converts and where Saudi tenders are won (local-content / iktiva scoring).
+
+The single most valuable thread running through the set is **Saudi local content & Saudization** (Aramco vendor listing → GACA aviation local content → MoE/Etimad school tenders → government tenders → giga-projects). That is UNEOM's structural moat as an in-Kingdom manufacturer, and no competitor content owns it.
+
+**Cluster balance (30):** Healthcare 4 · Corporate/Government 4 · Industrial/Oil & Gas 3 · Hospitality 3 · Aviation 3 · Education 3 · Security 3 · Saudi-Modest 2 · Fabric-Tech 2 · Decision/Commercial 3.
+**Funnel balance:** Awareness ~4 · Consideration ~18 · Decision ~8 — deliberately weighted to consideration/decision because UNEOM monetises programme contracts, not ad impressions.
+
+---
+
+## The 30 pages
+
+> Format per page — **#. Title** `proposed-url` · *cluster · priority*
+> **Keyword:** primary | secondaries · **Intent/Funnel** · **Words** · **D/C** (estimate)
+> **Gap:** what's missing today. **Linking:** pillar parent → inbound (who links in) → outbound (where it links).
+
+---
+
+### ⛽ Industrial / Oil & Gas — the highest commercial-intent cluster in the Kingdom
+
+**1. Saudi Aramco PPE & Coverall Vendor Specification Guide** `/resources/aramco-ppe-coverall-vendor-spec-guide/` · *industrial · **P1***
+**Keyword:** `saudi aramco ppe specification coveralls` | SAES standards, approved-vendor listing, contractor PPE compliance, Aramco FR coverall
+**Intent:** commercial / consideration · **Words:** 2,200 · **D: High / C: High**
+**Gap:** Nothing maps uniforms/PPE to Aramco's vendor-approval reality (SAES specs, approved-vendor listing, contractor site rules) — the single highest-value query an industrial procurement lead in the Eastern Province can search.
+**Linking:** Parent `/industries/manufacturing/`. Inbound ← `/industries/manufacturing/` ("Aramco PPE vendor specifications"), `/resources/electrical-safety-ppe-guide/`, `/blog/industrial-safety-workwear-saudi/`, `/case-studies/factory-safety-improvement/` ("HRC2 inherent FR programme"). Outbound → `/resources/fr-coverall-buyer-guide-saudi/`, `/resources/made-in-saudi-uniform-local-content-guide/`, `/services/program-management/`, `/shop/manufacturing/`.
+
+**2. FR Coverall Buyer's Guide for Saudi Oil & Gas** `/resources/fr-coverall-buyer-guide-saudi/` · *industrial · **P1***
+**Keyword:** `fr coverall buyer guide saudi arabia` | inherent vs treated FR, Nomex vs Proban, arc-flash coverall, FR coverall total cost of ownership
+**Intent:** commercial / decision · **Words:** 2,400 · **D: High / C: High**
+**Gap:** No decision-stage page compares inherent vs treated FR, brand tiers, and lifetime cost — the core spend decision for every refinery/petrochemical buyer.
+**Linking:** Parent `/industries/manufacturing/`. Inbound ← `/industries/manufacturing/`, `/resources/electrical-safety-ppe-guide/`, `/resources/aramco-ppe-coverall-vendor-spec-guide/`, `/blog/industrial-heat-stress-management/`. Outbound → `/shop/manufacturing/` ("HRC2 FR coverall"), `/resources/aramco-ppe-coverall-vendor-spec-guide/`, `/services/bulk-ordering/`, `/resources/uniform-price-index-ksa/`.
+
+**3. Megaproject & Construction Workwear: NEOM, Red Sea & Jubail** `/blog/megaproject-construction-workwear-neom-saudi/` · *industrial · **P1***
+**Keyword:** `construction site workwear saudi arabia` | NEOM contractor workwear, megaproject PPE, hi-vis site durability, Jubail construction uniform
+**Intent:** commercial / consideration · **Words:** 1,900 · **D: High / C: High**
+**Gap:** The giga-project construction workforce (heat + hi-vis + site-grade durability) has no dedicated page; ties the industrial cluster to the giga-project hub.
+**Linking:** Parent `/industries/manufacturing/`. Inbound ← `/industries/manufacturing/`, `/blog/industrial-heat-stress-management/`, `/resources/weather-protection-guide/`, `/industries/giga-project-uniforms/`. Outbound → `/industries/giga-project-uniforms/`, `/resources/fr-coverall-buyer-guide-saudi/`, `/shop/manufacturing/`, `/services/program-management/`.
+
+---
+
+### 🏛️ Corporate & Government — the largest employer base in KSA
+
+**4. Government & Ministry Staff Uniforms — Definitive Procurement Guide** `/industries/government-uniforms/` · *corporate-gov · **P1** · pillar-hub*
+**Keyword:** `government uniforms saudi arabia` | ministry staff uniforms KSA, public-sector uniform programme, government entity uniform supplier, وزارة زي موحد
+**Intent:** commercial / consideration · **Words:** 3,200 · **D: Med / C: High**
+**Gap:** Government is the Kingdom's biggest single employer, yet there is no hub for ministry/agency uniform programmes, Etimad procurement, or public-sector identity standards.
+**Linking:** Parent `/industries/corporate/`. Inbound ← `/industries/corporate/`, `/blog/national-day-corporate-uniforms/`, `/blog/corporate-dress-code-evolution/`, `/resources/procurement-guide/`. Outbound (hub) → `/resources/made-in-saudi-uniform-local-content-guide/`, `/resources/procurement-guide/`, `/services/program-management/`, `/shop/corporate/`, `/blog/bank-branch-staff-uniforms-saudi/`, `/resources/school-uniform-moe-tender-guide/`.
+
+**5. Vision 2030 Giga-Project Workforce Uniforms** `/industries/giga-project-uniforms/` · *corporate-gov · **P1** · pillar-hub*
+**Keyword:** `neom uniform supplier` | giga-project workforce uniform, Red Sea Global staff uniform, Qiddiya uniform, Diriyah workforce apparel
+**Intent:** commercial / consideration · **Words:** 3,300 · **D: Med / C: High**
+**Gap:** No page addresses the cross-trade workforce of NEOM/Red Sea/Qiddiya/Diriyah — a multi-billion-riyal, multi-year uniform demand that spans construction, hospitality, security and admin under one programme owner.
+**Linking:** Parent `/industries/corporate/` (cross-link `/industries/manufacturing/`). Inbound ← `/industries/corporate/`, `/industries/manufacturing/`, `/blog/megaproject-construction-workwear-neom-saudi/`, `/resources/made-in-saudi-uniform-local-content-guide/`. Outbound → `/blog/megaproject-construction-workwear-neom-saudi/`, `/resources/event-crowd-security-uniforms-saudi/`, `/resources/facility-management-cleaning-staff-uniforms-saudi/`, `/services/program-management/`, `/resources/aramco-ppe-coverall-vendor-spec-guide/`.
+
+**6. Bank Branch Staff Uniforms in Saudi Arabia** `/blog/bank-branch-staff-uniforms-saudi/` · *corporate-gov · **P2***
+**Keyword:** `bank uniforms saudi arabia` | teller uniform, relationship manager attire, bank branch identity, financial-sector uniform supplier
+**Intent:** commercial / consideration · **Words:** 2,000 · **D: Med / C: High**
+**Gap:** Banking is a high-AOV, brand-strict, multi-branch buyer with no dedicated page (tellers vs RMs vs branch managers, modest options, identity standards).
+**Linking:** Parent `/industries/corporate/`. Inbound ← `/industries/corporate/`, `/blog/corporate-uniform-programme-roi/`, `/blog/corporate-dress-code-evolution/`, `/industries/government-uniforms/`. Outbound → `/shop/corporate/`, `/blog/corporate-modest-workwear-abaya-saudi/`, `/services/custom-design/`, `/services/program-management/`.
+
+**7. Corporate Modest Workwear & Abaya for Saudi Women Professionals** `/blog/corporate-modest-workwear-abaya-saudi/` · *corporate-gov · **P1***
+**Keyword:** `corporate abaya uniform saudi arabia` | branded corporate abaya, modest workwear women KSA, professional hijab uniform, tailored office abaya
+**Intent:** commercial / consideration · **Words:** 2,000 · **D: High / C: High**
+**Gap:** With a fast-growing female professional workforce under Vision 2030, branded/tailored corporate abaya + modest workwear is a top procurement concern mentioned only in passing today.
+**Linking:** Parent `/industries/corporate/`. Inbound ← `/industries/corporate/`, `/blog/corporate-dress-code-evolution/`, `/blog/medical-hijab-healthcare-standards/`, `/blog/bank-branch-staff-uniforms-saudi/`. Outbound → `/shop/corporate/`, `/services/custom-design/`, `/resources/modest-scrubs-spec-guide-saudi/`, `/blog/modest-hospitality-uniforms-hijab-saudi/`, `/resources/made-in-saudi-uniform-local-content-guide/`.
+
+---
+
+### 🏥 Healthcare — deepen the strongest existing cluster
+
+**8. Hospital Scrub Color-Coding Policy (Department & Role Guide)** `/resources/hospital-scrub-color-coding-policy-saudi/` · *healthcare · **P1***
+**Keyword:** `hospital scrub color coding policy` | scrub colours by department, nurse scrub colour code, colour-coded scrubs policy, MOH scrub standardisation
+**Intent:** informational / consideration · **Words:** 2,000 · **D: High / C: High**
+**Gap:** No page governs who-wears-what-colour (OR vs ward vs ER vs paeds) or how to write a hospital-wide policy — a top procurement/HR input that drives bulk re-orders.
+**Linking:** Parent `/industries/healthcare/`. Inbound ← `/industries/healthcare/`, `/resources/nursing-uniform-guide/`, `/resources/healthcare-uniform-standards/`, `/blog/industrial-uniform-color-coding/` (colour-system cross-ref). Outbound → `/shop/medical-scrubs/`, `/resources/surgical-or-scrubs-specification-guide/`, `/resources/cbahi-accreditation-uniform-requirements/`, `/services/program-management/`.
+
+**9. CBAHI Accreditation Uniform & Dress-Code Requirements** `/resources/cbahi-accreditation-uniform-requirements/` · *healthcare · **P1***
+**Keyword:** `cbahi uniform requirements` | CBAHI dress code, hospital accreditation uniform, infection-control attire, JCI dress code KSA
+**Intent:** informational / consideration · **Words:** 2,100 · **D: Med / C: High**
+**Gap:** Existing standards content covers textile compliance (SFDA/SASO/AATCC) but never maps attire to CBAHI survey criteria — and accreditation cycles force full-facility uniform decisions.
+**Linking:** Parent `/industries/healthcare/`. Inbound ← `/industries/healthcare/`, `/resources/healthcare-uniform-standards/`, `/resources/nursing-uniform-guide/`, `/blog/medical-hijab-healthcare-standards/`. Outbound → `/resources/hospital-scrub-color-coding-policy-saudi/`, `/resources/surgical-or-scrubs-specification-guide/`, `/services/program-management/`, `/shop/medical-scrubs/`, `/resources/procurement-guide/`.
+
+**10. Surgical & OR Scrubs — Sterile-Zone Specification Guide** `/resources/surgical-or-scrubs-specification-guide/` · *healthcare · **P2***
+**Keyword:** `surgical scrubs saudi arabia` | OR scrubs specification, operating-room attire, sterile scrubs supplier, ceil-blue surgical scrubs
+**Intent:** commercial / consideration · **Words:** 2,000 · **D: Med / C: High**
+**Gap:** A higher-margin specialty line (lint-shedding limits, autoclave tolerance, restricted-zone rules, theatre colour conventions) with no dedicated page.
+**Linking:** Parent `/industries/healthcare/`. Inbound ← `/industries/healthcare/`, `/shop/medical-scrubs/`, `/resources/hospital-scrub-color-coding-policy-saudi/`, `/resources/cbahi-accreditation-uniform-requirements/`. Outbound → `/shop/medical-scrubs/`, `/resources/fabric-guide/`, `/resources/cleanroom-best-practices/`, `/services/custom-design/`.
+
+**11. Pharmacy Uniforms — Retail & Hospital Pharmacist Attire** `/resources/pharmacy-uniforms-guide-saudi/` · *healthcare · **P2***
+**Keyword:** `pharmacy uniforms saudi arabia` | pharmacist coat supplier, retail pharmacy staff uniform, hospital pharmacy scrubs, multi-branch pharmacy attire
+**Intent:** commercial / consideration · **Words:** 1,700 · **D: Med / C: High**
+**Gap:** Big multi-branch retail-pharmacy chains (Nahdi/Al-Dawaa-scale) are major bulk accounts with zero coverage; bridges healthcare ↔ retail.
+**Linking:** Parent `/industries/healthcare/`. Inbound ← `/industries/healthcare/`, `/shop/medical-scrubs/`, `/industries/retail/`, `/resources/nursing-uniform-guide/`. Outbound → `/shop/medical-scrubs/`, `/services/bulk-ordering/`, `/services/custom-design/`, `/resources/procurement-guide/`, `/shop/retail/`.
+
+---
+
+### 🏨 Hospitality — fill the role/segment gaps around the existing pillar
+
+**12. Café & Barista Uniforms (Specialty Coffee Brand Apparel)** `/blog/cafe-barista-uniforms-saudi/` · *hospitality · **P2***
+**Keyword:** `barista uniforms saudi arabia` | café staff uniform, coffee-shop apron supplier, specialty coffee uniform, apron & tee programme
+**Intent:** commercial / consideration · **Words:** 1,800 · **D: High / C: High**
+**Gap:** One of the world's fastest-growing specialty-coffee markets (Half Million, Barn's, Dose) — distinct apron/stain-release/casual-brand needs not covered by the restaurant or chef guides.
+**Linking:** Parent `/industries/hospitality/`. Inbound ← `/industries/hospitality/`, `/blog/chef-uniform-design-guide/`, `/blog/hotel-staff-uniform-guide/`, `/shop/hospitality-attire/`. Outbound → `/shop/hospitality-attire/`, `/services/custom-design/`, `/services/bulk-ordering/`, `/blog/qsr-vs-fine-dining-uniforms-saudi/`.
+
+**13. QSR vs Fine Dining Uniforms — Which Programme Model Fits?** `/blog/qsr-vs-fine-dining-uniforms-saudi/` · *hospitality · **P2** · comparison*
+**Keyword:** `qsr vs fine dining uniforms` | quick-service restaurant uniform, fast-food staff uniform, fine-dining waiter uniform, restaurant uniform cost comparison
+**Intent:** commercial / decision · **Words:** 2,300 · **D: Med / C: High**
+**Gap:** No page contrasts the two opposite F&B operating models (high-rotation low-cost QSR vs low-rotation premium formalwear) on cost-per-employee and rotation cycles.
+**Linking:** Parent `/industries/hospitality/`. Inbound ← `/industries/hospitality/`, `/blog/hotel-staff-uniform-guide/`, `/blog/chef-uniform-design-guide/`, `/blog/cafe-barista-uniforms-saudi/`. Outbound → `/shop/hospitality-attire/`, `/services/bulk-ordering/`, `/services/program-management/`, `/blog/uniform-rental-vs-purchase-saudi-arabia/`.
+
+**14. Modest & Abaya-Friendly Hospitality Uniforms** `/blog/modest-hospitality-uniforms-hijab-saudi/` · *hospitality · **P1***
+**Keyword:** `modest hospitality uniforms saudi` | hijab-friendly hotel uniform, abaya-style staff uniform, modest waitress uniform, female hospitality uniform KSA
+**Intent:** commercial / consideration · **Words:** 1,900 · **D: High / C: High**
+**Gap:** Saudization is putting a fast-growing female workforce into hospitality front-line roles; integrated-hijab tailoring and modest service-wear is a first-question procurement concern with no owner.
+**Linking:** Parent `/industries/hospitality/`. Inbound ← `/industries/hospitality/`, `/blog/hotel-staff-uniform-guide/`, `/blog/hospitality-uniforms-cultural-identity/`, `/blog/corporate-modest-workwear-abaya-saudi/`. Outbound → `/shop/hospitality-attire/`, `/services/custom-design/`, `/blog/corporate-modest-workwear-abaya-saudi/`, `/resources/made-in-saudi-uniform-local-content-guide/`.
+
+---
+
+### ✈️ Aviation — beyond cabin crew
+
+**15. Pilot & Flight Deck Uniforms (Rank Insignia, Epaulettes, GACA)** `/blog/pilot-uniform-rank-insignia-saudi/` · *aviation · **P2***
+**Keyword:** `pilot uniform saudi arabia` | pilot rank insignia stripes, airline epaulettes supplier, captain/first-officer uniform, flight-deck uniform GACA
+**Intent:** commercial / consideration · **Words:** 1,900 · **D: Med / C: High**
+**Gap:** The whole existing aviation cluster is cabin-crew/ground-staff; the flight deck (rank-bar hierarchy, wings, peaked caps, seated-cockpit fit) is absent.
+**Linking:** Parent `/industries/aviation/`. Inbound ← `/industries/aviation/`, `/shop/aviation/`, `/blog/riyadh-air-aviation-uniform-standards/`, `/blog/saudi-airline-uniform-programmes-compared/`. Outbound → `/shop/aviation/`, `/services/custom-design/`, `/resources/gaca-local-content-aviation-uniform-procurement/`, `/blog/saudi-airline-uniform-programmes-compared/`.
+
+**16. GACA Local-Content & Saudization in Aviation Procurement** `/resources/gaca-local-content-aviation-uniform-procurement/` · *aviation · **P1***
+**Keyword:** `gaca local content uniform procurement` | aviation uniform local content, Vision 2030 aviation Saudization, made-in-Saudi airline uniform, carrier tender localization
+**Intent:** commercial / consideration · **Words:** 2,000 · **D: Med / C: High**
+**Gap:** Local-content weighting decides aviation tenders as Riyadh Air/Saudia/flynas/flyadeal scale — UNEOM's strongest commercial differentiator, connected to nothing today.
+**Linking:** Parent `/industries/aviation/`. Inbound ← `/industries/aviation/`, `/blog/riyadh-air-aviation-uniform-standards/`, `/resources/procurement-guide/`, `/resources/made-in-saudi-uniform-local-content-guide/`. Outbound → `/resources/made-in-saudi-uniform-local-content-guide/`, `/services/program-management/`, `/shop/aviation/`, `/blog/saudi-airline-uniform-programmes-compared/`.
+
+**17. Saudia vs flynas vs flyadeal vs Riyadh Air — Programmes Compared** `/blog/saudi-airline-uniform-programmes-compared/` · *aviation · **P2** · comparison*
+**Keyword:** `saudi airline uniform programme comparison` | full-service vs low-cost carrier uniform, flynas uniform supplier, Riyadh Air uniform spec, airline uniform tender
+**Intent:** commercial / decision · **Words:** 2,200 · **D: Med / C: High**
+**Gap:** A decision-stage benchmark across carrier business models (fabric tier, piece-count, replacement SLA, branding spend) that helps a procurement lead size their own programme.
+**Linking:** Parent `/industries/aviation/`. Inbound ← `/industries/aviation/`, `/blog/riyadh-air-aviation-uniform-standards/`, `/shop/aviation/`, `/blog/pilot-uniform-rank-insignia-saudi/`. Outbound → `/shop/aviation/`, `/resources/gaca-local-content-aviation-uniform-procurement/`, `/blog/pilot-uniform-rank-insignia-saudi/`, `/services/program-management/`, `/resources/uniform-price-index-ksa/`.
+
+---
+
+### 🎓 Education — open the higher-ed and tender fronts
+
+**18. University & Higher-Education Uniforms** `/industries/university-uniforms-saudi-arabia/` · *education · **P1** · pillar-hub*
+**Keyword:** `university uniforms saudi arabia` | lab coats for universities, faculty staff uniforms, higher-education uniform supplier, medical-college lab coat supplier
+**Intent:** commercial / consideration · **Words:** 2,800 · **D: Med / C: High**
+**Gap:** The education pillar is K-12 only; higher ed (branded faculty attire, department-colour lab coats, campus crews, term-cycle tenders) is a distinct high-AOV buyer with no landing.
+**Linking:** Parent `/industries/education/`. Inbound ← `/industries/education/`, `/shop/education/`, `/blog/cultural-identity-saudi-school-uniforms/`, `/resources/school-uniform-moe-tender-guide/`. Outbound (hub) → `/shop/education/`, `/resources/fabric-guide/`, `/resources/school-uniform-moe-tender-guide/`, `/services/program-management/`, `/services/bulk-ordering/`, `/resources/surgical-or-scrubs-specification-guide/` (medical-faculty lab coats).
+
+**19. School Uniform Tenders & MoE / Etimad Procurement** `/resources/school-uniform-moe-tender-guide/` · *education · **P1***
+**Keyword:** `school uniform tender saudi arabia` | MoE uniform procurement, Etimad school uniform bid, government school uniform contract, school uniform RFP requirements
+**Intent:** informational / decision · **Words:** 2,100 · **D: Med / C: High**
+**Gap:** The largest single education buyer (MoE) procures via Etimad with SASO Quality Mark + OEKO-TEX clauses and local-content scoring — none of which the generic tender blog covers.
+**Linking:** Parent `/industries/education/`. Inbound ← `/industries/education/`, `/blog/uniform-procurement-tender-guide-saudi/`, `/resources/procurement-guide/`, `/blog/public-private-international-school-uniforms-saudi/`. Outbound → `/blog/public-private-international-school-uniforms-saudi/`, `/resources/made-in-saudi-uniform-local-content-guide/`, `/shop/education/`, `/services/program-management/`.
+
+**20. Public vs Private vs International School Uniforms — Buyer's Comparison** `/blog/public-private-international-school-uniforms-saudi/` · *education · **P2** · comparison*
+**Keyword:** `private vs international school uniforms saudi arabia` | international school uniform supplier Riyadh, private school uniform programme, British-curriculum school uniform, public school uniform tender
+**Intent:** commercial / decision · **Words:** 2,200 · **D: Med / C: High**
+**Gap:** The three segments buy completely differently (MoE-standardised vs crest-led private vs house-system international) — no side-by-side exists.
+**Linking:** Parent `/industries/education/`. Inbound ← `/industries/education/`, `/blog/cultural-identity-saudi-school-uniforms/`, `/shop/education/`, `/resources/school-uniform-moe-tender-guide/`. Outbound → `/shop/education/`, `/resources/school-uniform-moe-tender-guide/`, `/services/custom-design/`, `/resources/size-guide/`, `/industries/university-uniforms-saudi-arabia/`.
+
+---
+
+### 🛡️ Security & Facilities
+
+**21. Facility Management & Cleaning Staff Uniforms** `/resources/facility-management-cleaning-staff-uniforms-saudi/` · *security · **P1** · pillar-hub*
+**Keyword:** `facility management staff uniforms saudi arabia` | cleaning staff uniform, FM workforce apparel, janitorial uniform supplier, soft-services uniform programme
+**Intent:** commercial / consideration · **Words:** 3,000 · **D: High / C: High**
+**Gap:** FM/soft-services is a massive, fast-consolidating KSA sector (giga-project facilities, integrated FM contracts) with no home — distinct from guarding.
+**Linking:** Parent `/industries/security/`. Inbound ← `/industries/security/`, `/industries/manufacturing/`, `/resources/professional-security-standards/`, `/industries/giga-project-uniforms/`. Outbound (hub) → `/shop/security/`, `/services/bulk-ordering/`, `/services/program-management/`, `/resources/event-crowd-security-uniforms-saudi/`, `/resources/hcis-security-uniform-compliance-checklist/`, `/resources/uniform-price-index-ksa/`.
+
+**22. HCIS Private-Security Uniform Compliance Checklist** `/resources/hcis-security-uniform-compliance-checklist/` · *security · **P1***
+**Keyword:** `hcis security uniform compliance requirements` | HCIS uniform audit, private-security uniform standards, security guard uniform regulation KSA, audit-readiness checklist
+**Intent:** informational / consideration · **Words:** 2,000 · **D: Med / C: High**
+**Gap:** Private-security firms must pass HCIS-aligned audits; an actionable compliance/audit-readiness checklist is exactly what their ops managers search and nothing provides.
+**Linking:** Parent `/industries/security/`. Inbound ← `/industries/security/`, `/resources/security-equipment-standards/`, `/resources/professional-security-standards/`, `/resources/event-crowd-security-uniforms-saudi/`. Outbound → `/shop/security/`, `/resources/professional-security-standards/`, `/resources/event-crowd-security-uniforms-saudi/`, `/services/program-management/`.
+
+**23. Event & Crowd Security Uniforms (Riyadh Season, Stadiums)** `/resources/event-crowd-security-uniforms-saudi/` · *security · **P2***
+**Keyword:** `event security uniforms saudi arabia` | crowd-control uniform, stadium security uniform, Riyadh Season security apparel, seasonal-event guard uniform
+**Intent:** commercial / consideration · **Words:** 2,000 · **D: High / C: High**
+**Gap:** Saudi's events boom (Riyadh Season, mega-events, stadiums) needs surge-deployment, high-visibility, identity-clear security kit — an uncovered, high-volume seasonal buyer.
+**Linking:** Parent `/industries/security/`. Inbound ← `/industries/security/`, `/resources/professional-security-standards/`, `/resources/hcis-security-uniform-compliance-checklist/`, `/industries/giga-project-uniforms/`. Outbound → `/shop/security/`, `/resources/hcis-security-uniform-compliance-checklist/`, `/resources/security-equipment-standards/`, `/services/bulk-ordering/`, `/industries/giga-project-uniforms/`.
+
+---
+
+### 🌙 Saudi-Modest & Local Content — the distinctive moat
+
+**24. Made-in-Saudi Uniforms: Local Content, Saudization & the In-Kingdom Advantage** `/resources/made-in-saudi-uniform-local-content-guide/` · *saudi-modest · **P1** · pillar-hub / magnet*
+**Keyword:** `made in saudi uniforms` | local content uniform Saudi, iktiva local content, Saudization manufacturing, in-Kingdom uniform supplier
+**Intent:** commercial / consideration · **Words:** 2,800 · **D: Med / C: High**
+**Gap:** Local-content / iktiva scoring is the deciding factor in government, aviation, education and giga-project tenders — and UNEOM's structural moat as a local manufacturer. This is the page every tender-facing page should link into.
+**Linking:** Parent `/services/program-management/`. Inbound (magnet) ← `/industries/government-uniforms/`, `/resources/gaca-local-content-aviation-uniform-procurement/`, `/resources/school-uniform-moe-tender-guide/`, `/resources/aramco-ppe-coverall-vendor-spec-guide/`, `/resources/procurement-guide/`. Outbound → `/services/program-management/`, `/resources/sustainability-guide/`, `/industries/giga-project-uniforms/`, `/about/`, `/resources/procurement-guide/`.
+
+**25. Modest Scrubs for Saudi Healthcare (Coverage, CBAHI, Infection-Control)** `/resources/modest-scrubs-spec-guide-saudi/` · *saudi-modest · **P2***
+**Keyword:** `modest scrubs saudi arabia` | full-coverage scrubs, hijab-compatible scrubs, modest nurse uniform, infection-control modest attire
+**Intent:** commercial / consideration · **Words:** 1,900 · **D: High / C: High**
+**Gap:** Modest scrubs sit at the intersection of healthcare + modest demand; the existing medical-hijab post is cultural, not a buyer-facing spec (coverage, sleeve rules vs bare-below-elbow, fabric).
+**Linking:** Parent `/industries/healthcare/`. Inbound ← `/industries/healthcare/`, `/blog/medical-hijab-healthcare-standards/`, `/resources/nursing-uniform-guide/`, `/resources/cbahi-accreditation-uniform-requirements/`. Outbound → `/shop/medical-scrubs/`, `/resources/hospital-scrub-color-coding-policy-saudi/`, `/blog/medical-hijab-healthcare-standards/`, `/services/custom-design/`, `/blog/corporate-modest-workwear-abaya-saudi/`.
+
+---
+
+### 🧵 Fabric Technology — definitional authority + AI-overview wins
+
+**26. Cooling & Moisture-Wicking Uniform Fabrics for Saudi Heat** `/resources/cooling-moisture-wicking-fabric-guide/` · *fabric-tech · **P1***
+**Keyword:** `moisture wicking uniform fabric saudi arabia` | cooling uniform fabric, breathable workwear fabric, heat-management uniform, performance fabric KSA
+**Intent:** informational / consideration · **Words:** 2,000 · **D: High / C: High**
+**Gap:** Heat is the universal Saudi uniform problem; a B2B performance-fabric guide (wicking mechanisms, GSM, weave, what to spec) is high-demand and feeds every industry cluster.
+**Linking:** Parent `/services/fabric-selection/`. Inbound ← `/services/fabric-selection/`, `/resources/fabric-guide/`, `/blog/uniform-fabric-guide-saudi-climate/`, `/blog/industrial-heat-stress-management/`. Outbound → `/resources/fabric-guide/`, `/resources/poly-cotton-blend-ratios-guide/`, `/resources/weather-protection-guide/`, `/shop/manufacturing/`.
+
+**27. Poly-Cotton Blend Ratios Decoded (65/35 vs 80/20 vs 50/50)** `/resources/poly-cotton-blend-ratios-guide/` · *fabric-tech · **P2***
+**Keyword:** `poly cotton blend ratio for uniforms` | 65/35 vs 80/20 uniform fabric, polycotton uniform blend, best fabric blend workwear, durable vs comfortable uniform fabric
+**Intent:** informational / consideration · **Words:** 1,900 · **D: High / C: High**
+**Gap:** The most foundational fabric question buyers ask, with no dedicated authority page — a perennial-demand, snippet-winning explainer that links into every product cluster.
+**Linking:** Parent `/services/fabric-selection/`. Inbound ← `/services/fabric-selection/`, `/resources/fabric-guide/`, `/blog/uniform-fabric-guide-saudi-climate/`, `/resources/cooling-moisture-wicking-fabric-guide/`. Outbound → `/resources/fabric-guide/`, `/resources/cooling-moisture-wicking-fabric-guide/`, `/shop/corporate/`, `/services/quality-assurance/`, `/resources/size-guide/`.
+
+---
+
+### 💼 Decision & Commercial — bottom-funnel conversion + the master hub
+
+**28. Uniform Rental vs Purchase in Saudi Arabia** `/blog/uniform-rental-vs-purchase-saudi-arabia/` · *decision · **P1** · comparison*
+**Keyword:** `uniform rental vs purchase` | uniform leasing Saudi Arabia, rent vs buy uniforms, uniform programme cost control, managed uniform rental
+**Intent:** commercial / decision · **Words:** 2,200 · **D: Med / C: High**
+**Gap:** A classic high-intent decision query with no page; a natural conversion point that routes to programme management.
+**Linking:** Parent `/services/program-management/`. Inbound ← `/services/program-management/`, `/resources/procurement-guide/`, `/blog/corporate-uniform-programme-roi/`, `/resources/saudi-uniform-buyers-guide/`. Outbound → `/resources/saudi-uniform-buyers-guide/`, `/resources/uniform-price-index-ksa/`, `/services/program-management/`, `/services/bulk-ordering/`.
+
+**29. Embroidery vs Screen Print vs Heat Transfer — Logo Method Guide** `/blog/embroidery-vs-screen-print-vs-heat-transfer-uniforms/` · *decision · **P2** · comparison*
+**Keyword:** `embroidery vs screen printing uniforms` | uniform logo embroidery, heat-transfer uniform branding, screen print vs embroidery, uniform branding methods
+**Intent:** commercial / decision · **Words:** 2,000 · **D: Med / C: High**
+**Gap:** Evergreen branding-method comparison every buyer needs (durability, cost, MOQ, fabric suitability) — missing entirely.
+**Linking:** Parent `/services/custom-design/`. Inbound ← `/services/custom-design/`, `/blog/national-day-corporate-uniforms/`, `/shop/corporate/`, `/resources/saudi-uniform-buyers-guide/`. Outbound → `/services/custom-design/`, `/shop/corporate/`, `/blog/bank-branch-staff-uniforms-saudi/`, `/services/quality-assurance/`, `/resources/fabric-guide/`.
+
+**30. The Complete Uniform Buyer's Guide for Saudi Arabia (Brief → Reorder)** `/resources/saudi-uniform-buyers-guide/` · *decision · **P1** · pillar-hub / magnet*
+**Keyword:** `uniform buyers guide saudi arabia` | how to buy uniforms for a company, uniform procurement process, corporate uniform sourcing, uniform RFP guide
+**Intent:** informational / consideration · **Words:** 3,200 · **D: Med / C: High**
+**Gap:** No top-level money-hub orchestrates the whole journey (brief → fabric → fit → branding → tender → reorder). This is the page the homepage and every cluster should point to, and the second authority magnet.
+**Linking:** Parent: top-level (link from homepage). Inbound (magnet) ← `/` (homepage), `/resources/procurement-guide/`, `/blog/choosing-uniform-supplier-guide/`, `/resources/uniform-price-index-ksa/`. Outbound (mega-hub) → `/resources/procurement-guide/`, `/blog/uniform-rental-vs-purchase-saudi-arabia/`, `/blog/embroidery-vs-screen-print-vs-heat-transfer-uniforms/`, `/resources/fabric-guide/`, `/resources/size-guide/`, `/services/program-management/`, `/industries/` (industries hub).
+
+---
+
+## Internal-linking architecture — the five rules that make this a graph, not a list
+
+1. **Every new page links *up* to one existing pillar** (its "Parent") and the pillar links *down* to it within 2 weeks of publish. No orphans — that is what killed the v1 post-cluster (audit finding D2).
+2. **Sibling new pages cross-link inside their sub-cluster** (e.g. the four FR/industrial pages form a ring; the three aviation pages form a ring). This is what signals *depth* to Google, not just breadth.
+3. **The two magnets** — `/resources/made-in-saudi-uniform-local-content-guide/` and `/resources/saudi-uniform-buyers-guide/` — receive inbound links from every tender-facing and decision-facing page respectively. Concentrate authority where contracts are won.
+4. **Anchor text = the target keyword or a close semantic variant**, never "click here" / "read more." Anchors are specified per page above.
+5. **Cross-cluster bridges are deliberate**: pharmacy (healthcare↔retail), giga-project (corporate↔manufacturing↔security), modest workwear (corporate↔hospitality↔healthcare), local content (aviation↔education↔government↔industrial). These bridges are what make the authority "unbeatable" — competitors write siloed articles; this set is woven.
+
+---
+
+## Phased rollout
+
+**Wave 1 — P1 (build first, ~13 pages):** Aramco PPE spec, FR coverall buyer's guide, megaproject workwear, Government hub, Giga-project hub, Corporate modest/abaya, Scrub color-coding, CBAHI, Modest hospitality, GACA local content, University hub, MoE tender guide, FM hub, HCIS checklist, Made-in-Saudi magnet, Cooling fabrics, Rental-vs-purchase, Buyer's Guide magnet. *(These open the most sub-clusters and carry the highest commercial intent; build the two magnets early so later pages have something to link into.)*
+
+**Wave 2 — P2 (~12 pages):** Bank uniforms, Surgical/OR scrubs, Pharmacy, Café/barista, QSR vs fine-dining, Pilot uniforms, Airline comparison, Public/private/international schools, Event/crowd security, Modest scrubs, Poly-cotton ratios, Embroidery vs print.
+
+**Sequencing tip:** within each wave, publish the **hub before its spokes** where possible, so the spokes have a parent to link up to on day one.
+
+---
+
+## What this set deliberately does *not* include (and why)
+
+- **No programmatic city×industry pages.** The v2 architecture intentionally dropped thin pSEO; these 30 are all substantive editorial/hub pages. (If you ever want geo depth, do it as a handful of *real* metro-industry guides, not 192 auto-pages.)
+- **No fabricated E-E-A-T.** Several pages lean on named real standards/entities (Aramco SAES, CBAHI, GACA, HCIS, SASO, Etimad, OEKO-TEX) — that is the honest authority signal. Do **not** add invented reviews, ratings, or author credentials to these.
+- **Supporting layer (recommended, not in the 30):** 3–4 **glossaries** (a master uniform/procurement glossary, plus FR/PPE and fabric glossaries) are strong topical-authority and AI-overview assets but low commercial value, so they sit just below the top 30 as a Wave-3 "definitional layer" that internally links every cluster together.
+
+## Upgrade path: replace estimates with real data
+
+The architecture above is data-independent and durable. To harden the *prioritisation*, enable an Ahrefs/Semrush plan **or** grant Search Console property access, and the same 30 target keywords can be re-scored with real monthly volume, difficulty, and current-position data — promoting/demoting individual pages within the waves. The cluster structure and internal-linking map would not change; only the build order would sharpen.

--- a/src/app/(site)/resources/[slug]/page.tsx
+++ b/src/app/(site)/resources/[slug]/page.tsx
@@ -35,7 +35,12 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
   const r = RESOURCES_BY_SLUG[slug];
   if (!r) notFound();
 
-  const schema = guideSchema({ slug: r.slug, title: r.title, summary: r.summary, image: `/images/${r.hero}.avif` });
+  const schema = guideSchema({
+    slug: r.slug, title: r.title, summary: r.summary, image: `/images/${r.hero}.avif`,
+    type: r.schemaType, datePublished: r.datePublished, dateModified: r.dateModified,
+    proficiencyLevel: r.schemaType === 'TechArticle' ? 'Expert' : undefined,
+    faqs: r.faqs
+  });
 
   return (
     <>
@@ -95,6 +100,23 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
               </section>
             ))}
           </div>
+
+          {/* FAQ — visible content that mirrors the FAQPage JSON-LD */}
+          {r.faqs && r.faqs.length > 0 && (
+            <section id="faq" className="mt-16">
+              <h2 className="text-display text-navy-900 balance">Frequently asked questions</h2>
+              <dl className="mt-8 space-y-4">
+                {r.faqs.map((f, i) => (
+                  <details key={i} className="group rounded-2xl border border-ink-100 bg-white p-6 open:bg-ink-50">
+                    <summary className="cursor-pointer list-none text-lg font-semibold text-navy-900 marker:hidden">
+                      {f.q}
+                    </summary>
+                    <p className="mt-4 text-lg leading-relaxed text-ink-500 pretty">{f.a}</p>
+                  </details>
+                ))}
+              </dl>
+            </section>
+          )}
 
           {/* References */}
           {r.references && r.references.length > 0 && (

--- a/src/app/ar/resources/[slug]/page.tsx
+++ b/src/app/ar/resources/[slug]/page.tsx
@@ -36,7 +36,12 @@ export default async function ArResourcePage({ params }: { params: Promise<{ slu
   const r = RESOURCES_BY_SLUG[slug];
   if (!r) notFound();
 
-  const schema = guideSchema({ slug: r.slug, title: r.titleAr, summary: r.summaryAr, image: `/images/${r.hero}.avif`, locale: 'ar' });
+  const schema = guideSchema({
+    slug: r.slug, title: r.titleAr, summary: r.summaryAr, image: `/images/${r.hero}.avif`, locale: 'ar',
+    type: r.schemaType, datePublished: r.datePublished, dateModified: r.dateModified,
+    proficiencyLevel: r.schemaType === 'TechArticle' ? 'Expert' : undefined,
+    faqs: r.faqsAr
+  });
 
   return (
     <>
@@ -87,6 +92,23 @@ export default async function ArResourcePage({ params }: { params: Promise<{ slu
               <p className="mt-4 text-lg leading-relaxed text-ink-500 pretty">{s.body}</p>
             </section>
           ))}
+
+          {/* الأسئلة الشائعة — محتوى ظاهر يطابق بيانات FAQPage المنظمة */}
+          {r.faqsAr && r.faqsAr.length > 0 && (
+            <section id="faq" className="mt-12">
+              <h2 className="text-display text-navy-900">الأسئلة الشائعة</h2>
+              <dl className="mt-8 space-y-4">
+                {r.faqsAr.map((f, i) => (
+                  <details key={i} className="group rounded-2xl border border-ink-100 bg-white p-6 open:bg-ink-50">
+                    <summary className="cursor-pointer list-none text-lg font-semibold text-navy-900 marker:hidden">
+                      {f.q}
+                    </summary>
+                    <p className="mt-4 text-lg leading-relaxed text-ink-500 pretty">{f.a}</p>
+                  </details>
+                ))}
+              </dl>
+            </section>
+          )}
         </div>
 
         <div className="container-page section-tight">

--- a/src/lib/data/resources/index.ts
+++ b/src/lib/data/resources/index.ts
@@ -19,6 +19,13 @@ export interface Resource {
   relatedPosts?: string[];
   relatedCategories?: string[];
   references?: { name: string; url: string }[];
+  /** Schema @type for the article node. Technical/standards guides use 'TechArticle'. Defaults to 'Article'. */
+  schemaType?: 'Article' | 'TechArticle';
+  datePublished?: string;
+  dateModified?: string;
+  /** Optional FAQ. When present, the page renders a visible FAQ section AND emits FAQPage JSON-LD (schema must mirror visible content). */
+  faqs?: { q: string; a: string }[];
+  faqsAr?: { q: string; a: string }[];
 }
 
 import { fabricGuide } from './fabric-guide';

--- a/src/lib/seo/schemas.ts
+++ b/src/lib/seo/schemas.ts
@@ -552,17 +552,34 @@ export function jobPostingSchema(jobs: JobPostingOpts[]) {
 
 /* ─── RESOURCE / GUIDE ─── */
 
-export function guideSchema(opts: { slug: string; title: string; summary: string; image?: string; locale?: 'en' | 'ar' }) {
+export function guideSchema(opts: {
+  slug: string;
+  title: string;
+  summary: string;
+  image?: string;
+  locale?: 'en' | 'ar';
+  /** 'TechArticle' for standards/compliance/technical guides; defaults to 'Article'. */
+  type?: 'Article' | 'TechArticle';
+  datePublished?: string;
+  dateModified?: string;
+  proficiencyLevel?: 'Beginner' | 'Expert';
+  /** Topic entities for entity-SEO (rendered as schema:about Thing nodes). */
+  about?: string[];
+  keywords?: string;
+  /** When provided, emits a FAQPage node. The caller MUST also render these FAQs visibly — schema has to mirror on-page content. */
+  faqs?: { q: string; a: string }[];
+}) {
   const prefix = opts.locale === 'ar' ? '/ar' : '';
   const path = `${prefix}/resources/${opts.slug}/`;
   const pageId = `${SITE}${path}#webpage`;
   const imgId = `${SITE}${path}#primaryimage`;
-  // Was '@type': 'HowTo' with NO `step` array — invalid HowTo (Google rejects
-  // a HowTo lacking steps; it generates a Search Console structured-data error
-  // and zero rich results). These resources are reference guides, not literal
-  // step-by-step procedures, so Article is the correct, valid type.
+  const dateModified = opts.dateModified || opts.datePublished;
+  // Article vs TechArticle: technical/standards guides (Aramco PPE, FR specs,
+  // compliance checklists) are TechArticle — more specific, signals expert
+  // reference content. Never HowTo here (these are reference guides, not
+  // step-by-step procedures; a stepless HowTo is invalid and Google rejects it).
   const article = {
-    '@type': 'Article',
+    '@type': opts.type ?? 'Article',
     '@id': `${SITE}${path}#article`,
     headline: opts.title,
     name: opts.title,
@@ -572,19 +589,36 @@ export function guideSchema(opts: { slug: string; title: string; summary: string
     publisher: { '@id': ORG_ID },
     mainEntityOfPage: { '@id': pageId },
     isPartOf: { '@id': pageId },
-    inLanguage: opts.locale === 'ar' ? 'ar-SA' : 'en'
+    inLanguage: opts.locale === 'ar' ? 'ar-SA' : 'en',
+    ...(opts.datePublished ? { datePublished: opts.datePublished } : {}),
+    ...(dateModified ? { dateModified } : {}),
+    ...(opts.type === 'TechArticle' && opts.proficiencyLevel ? { proficiencyLevel: opts.proficiencyLevel } : {}),
+    ...(opts.about && opts.about.length ? { about: opts.about.map(name => ({ '@type': 'Thing', name })) } : {}),
+    ...(opts.keywords ? { keywords: opts.keywords } : {})
   };
-  return {
-    '@context': 'https://schema.org',
-    '@graph': [
-      webPageNode({
-        path, name: opts.title, description: opts.summary, locale: opts.locale,
-        type: 'WebPage', primaryImageId: opts.image ? imgId : undefined, hasBreadcrumb: true, speakableSelectors: ['h1']
-      }),
-      ...(opts.image ? [imageObjectNode({ url: opts.image, id: imgId, width: 1920, height: 1080, caption: opts.title })] : []),
-      article
-    ]
-  };
+  const graph: object[] = [
+    webPageNode({
+      path, name: opts.title, description: opts.summary, locale: opts.locale,
+      type: 'WebPage', datePublished: opts.datePublished, dateModified,
+      primaryImageId: opts.image ? imgId : undefined, hasBreadcrumb: true, speakableSelectors: ['h1']
+    }),
+    ...(opts.image ? [imageObjectNode({ url: opts.image, id: imgId, width: 1920, height: 1080, caption: opts.title })] : []),
+    article
+  ];
+  if (opts.faqs && opts.faqs.length) {
+    graph.push({
+      '@type': 'FAQPage',
+      '@id': `${SITE}${path}#faq`,
+      isPartOf: { '@id': pageId },
+      inLanguage: opts.locale === 'ar' ? 'ar-SA' : 'en',
+      mainEntity: opts.faqs.map(f => ({
+        '@type': 'Question',
+        name: f.q,
+        acceptedAnswer: { '@type': 'Answer', text: f.a }
+      }))
+    });
+  }
+  return { '@context': 'https://schema.org', '@graph': graph };
 }
 
 /* ─── PRODUCT (CENTRALIZED) ─── */


### PR DESCRIPTION
## Summary

Two strands of SEO/content-authority work:

### 1. Schema wiring — `TechArticle` + `FAQPage` for resource guides (`ae3f4ecb5`)
`guideSchema()` now accepts `type:'TechArticle'`, `faqs`, `datePublished`/`dateModified`, `proficiencyLevel`, `about[]`, and `keywords`. When `faqs` are supplied it appends a `FAQPage` node (`@id …#faq`, `isPartOf` the page's `#webpage`), and **both EN/AR resource templates render a visible FAQ section** so the structured data mirrors on-page content. The `Resource` type gains optional `schemaType` / `faqs` / `faqsAr` / dates.

- **Backward-compatible**: existing resources emit unchanged `Article` graphs.
- **Verified end-to-end** (EN + AR) via a temporary test that was reverted: `TechArticle` + `proficiencyLevel: Expert`, a `FAQPage` node with the right `@id`, a visible FAQ matching the schema, and **no dangling/duplicate `@id`s**. Build **344/344**, exit 0.

Files: `src/lib/seo/schemas.ts`, `src/lib/data/resources/index.ts`, `src/app/(site)/resources/[slug]/page.tsx`, `src/app/ar/resources/[slug]/page.tsx`.

### 2. Content-gap roadmap + flagship briefs (`28600b74e`)
- **`CONTENT-GAP-ANALYSIS-2026.md`** — 30 highest-leverage pages for topical authority across 10 clusters, each with target keyword, intent, word count, and internal-linking mapped to real existing URLs. Anchored by two "magnet" hubs (Made-in-Saudi local content, Buyer's Guide).
- **`CONTENT-BRIEF-01-aramco-ppe.md`** + **`CONTENT-BRIEF-24-made-in-saudi-local-content.md`** — full briefs: H2 outline, entity-SEO list, FAQ, paste-ready JSON-LD (using the new schema support), inbound/outbound linking.

## Honesty notes
- Demand figures are **labelled estimates** — both connected SEO data MCPs (Ahrefs, Semrush) are plan-gated, so no live keyword/GSC data was available.
- The briefs enforce a strict `[SME-VERIFY]` discipline: no fabricated Aramco SAES numbers, arc ratings, local-content percentages, or E-E-A-T.

## Test plan
- [x] `npm run build` → 344/344, exit 0
- [x] JSON-LD graph integrity (no dangling/dup `@id`) on EN + AR resource pages
- [x] Visible FAQ renders and matches `FAQPage` schema
- [ ] Validate a `TechArticle`+`FAQPage` page in Google Rich Results Test once a real guide is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)
